### PR TITLE
Add more data structure links and fix existing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,10 @@
 
 ## Data Structures
 
-- Queue
-	- [Queue](data-structures/queue/queue.cs)
-- Linked List
-	- [Linked List](data-structures/linked-list/linkedlist.cs)
+- [Queue](data-structures/queue.cs)
+- [Stack](data-structures/stack.cs)
+- [Linked List](data-structures/linkedlist.cs)
+- [Doubly-Linked List](data-structures/DoublyLinkedList.cs)
 
 ## Searches
 


### PR DESCRIPTION
Some of the links to the existing data structures were wrong, and some data structures links were not previously added. This fixes those two issues.

This also cleans up the formatting of the links so they look like the rest of the readme.